### PR TITLE
allow separate modification of JSON key & Elm record field names via `Options`

### DIFF
--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -11,11 +11,12 @@ import Formatting hiding (text)
 import Text.PrettyPrint.Leijen.Text hiding ((<$>), (<>))
 
 data Options = Options
-  { fieldLabelModifier :: Text -> Text
+  { elmRecordFieldModifier :: Text -> Text
+  , jsonKeyModifier :: Text -> Text
   }
 
 defaultOptions :: Options
-defaultOptions = Options {fieldLabelModifier = id}
+defaultOptions = Options {elmRecordFieldModifier = id, jsonKeyModifier = id}
 
 cr :: Format r r
 cr = now "\n"

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -111,7 +111,7 @@ instance HasDecoder ElmValue where
     dy <- render y
     return $ dx <$$> dy
   render (ElmField name value) = do
-    fieldModifier <- asks fieldLabelModifier
+    fieldModifier <- asks jsonKeyModifier
     dv <- render value
     return $ "|> required" <+> dquotes (stext (fieldModifier name)) <+> dv
   render ElmEmpty = pure (stext "")

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -120,11 +120,12 @@ renderEnumeration c = render c
 
 instance HasEncoder ElmValue where
   render (ElmField name value) = do
-    fieldModifier <- asks fieldLabelModifier
+    jsonFieldModifier <- asks jsonKeyModifier
+    elmFieldModifier <- asks elmRecordFieldModifier
     valueBody <- render value
     return . spaceparens $
-      dquotes (stext (fieldModifier name)) <> comma <+>
-      (valueBody <+> "x." <> stext name)
+      dquotes (stext (jsonFieldModifier name)) <> comma <+>
+      (valueBody <+> "x." <> stext (elmFieldModifier name))
   render (ElmPrimitiveRef primitive) = renderRef primitive
   render (ElmRef name) = pure $ "encode" <> stext name
   render (Values x y) = do

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -57,7 +57,7 @@ instance HasType ElmValue where
     dy <- render y
     return $ dx <+> dy
   render (ElmField name value) = do
-    fieldModifier <- asks fieldLabelModifier
+    fieldModifier <- asks elmRecordFieldModifier
     dv <- renderRecord value
     return $ stext (fieldModifier name) <+> ":" <+> dv
 

--- a/test/CommentEncoderWithOptions.elm
+++ b/test/CommentEncoderWithOptions.elm
@@ -8,10 +8,10 @@ import Json.Encode
 encodeComment : Comment -> Json.Encode.Value
 encodeComment x =
     Json.Encode.object
-        [ ( "commentPostId", Json.Encode.int x.postId )
-        , ( "commentText", Json.Encode.string x.text )
-        , ( "commentMainCategories", (Exts.Json.Encode.tuple2 Json.Encode.string Json.Encode.string) x.mainCategories )
-        , ( "commentPublished", Json.Encode.bool x.published )
-        , ( "commentCreated", (Json.Encode.string << Date.Extra.toUtcIsoString) x.created )
-        , ( "commentTags", (Exts.Json.Encode.dict Json.Encode.string Json.Encode.int) x.tags )
+        [ ( "jsonCommentPostId", Json.Encode.int x.elmCommentPostId )
+        , ( "jsonCommentText", Json.Encode.string x.elmCommentText )
+        , ( "jsonCommentMainCategories", (Exts.Json.Encode.tuple2 Json.Encode.string Json.Encode.string) x.elmCommentMainCategories )
+        , ( "jsonCommentPublished", Json.Encode.bool x.elmCommentPublished )
+        , ( "jsonCommentCreated", (Json.Encode.string << Date.Extra.toUtcIsoString) x.elmCommentCreated )
+        , ( "jsonCommentTags", (Exts.Json.Encode.dict Json.Encode.string Json.Encode.int) x.elmCommentTags )
         ]

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -180,7 +180,7 @@ toElmTypeSpec =
            , ""
            , "%s"
            ])
-        (defaultOptions {fieldLabelModifier = withPrefix "post"})
+        (defaultOptions {elmRecordFieldModifier = withPrefix "post"})
         (Proxy :: Proxy Post)
         "test/PostTypeWithOptions.elm"
     it "toElmTypeSourceWithOptions Comment" $
@@ -194,7 +194,7 @@ toElmTypeSpec =
            , ""
            , "%s"
            ])
-        (defaultOptions {fieldLabelModifier = withPrefix "comment"})
+        (defaultOptions {elmRecordFieldModifier = withPrefix "comment"})
         (Proxy :: Proxy Comment)
         "test/CommentTypeWithOptions.elm"
     describe "Convert to Elm type references." $ do
@@ -268,7 +268,7 @@ toElmDecoderSpec =
            , ""
            , "%s"
            ])
-        (defaultOptions {fieldLabelModifier = withPrefix "post"})
+        (defaultOptions {jsonKeyModifier = withPrefix "post"})
         (Proxy :: Proxy Post)
         "test/PostDecoderWithOptions.elm"
     it "toElmDecoderSource Position" $
@@ -330,7 +330,7 @@ toElmDecoderSpec =
            , ""
            , "%s"
            ])
-        (defaultOptions {fieldLabelModifier = withPrefix "comment"})
+        (defaultOptions {jsonKeyModifier = withPrefix "comment"})
         (Proxy :: Proxy Comment)
         "test/CommentDecoderWithOptions.elm"
     it "toElmDecoderSource Useless" $
@@ -450,7 +450,7 @@ toElmEncoderSpec =
            , ""
            , "%s"
            ])
-        (defaultOptions {fieldLabelModifier = withPrefix "comment"})
+        (defaultOptions {jsonKeyModifier = withPrefix "jsonComment", elmRecordFieldModifier = withPrefix "elmComment"})
         (Proxy :: Proxy Comment)
         "test/CommentEncoderWithOptions.elm"
     it "toElmEncoderSourceWithOptions Post" $
@@ -465,7 +465,7 @@ toElmEncoderSpec =
            , ""
            , "%s"
            ])
-        (defaultOptions {fieldLabelModifier = withPrefix "post"})
+        (defaultOptions {jsonKeyModifier = withPrefix "jsonPost", elmRecordFieldModifier = withPrefix "elmPost"})
         (Proxy :: Proxy Post)
         "test/PostEncoderWithOptions.elm"
     it "toElmEncoderSource Position" $

--- a/test/PostEncoderWithOptions.elm
+++ b/test/PostEncoderWithOptions.elm
@@ -8,10 +8,10 @@ import PostType exposing (..)
 encodePost : Post -> Json.Encode.Value
 encodePost x =
     Json.Encode.object
-        [ ( "postId", Json.Encode.int x.id )
-        , ( "postName", Json.Encode.string x.name )
-        , ( "postAge", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.float) x.age )
-        , ( "postComments", (Json.Encode.list << List.map encodeComment) x.comments )
-        , ( "postPromoted", (Maybe.withDefault Json.Encode.null << Maybe.map encodeComment) x.promoted )
-        , ( "postAuthor", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string) x.author )
+        [ ( "jsonPostId", Json.Encode.int x.elmPostId )
+        , ( "jsonPostName", Json.Encode.string x.elmPostName )
+        , ( "jsonPostAge", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.float) x.elmPostAge )
+        , ( "jsonPostComments", (Json.Encode.list << List.map encodeComment) x.elmPostComments )
+        , ( "jsonPostPromoted", (Maybe.withDefault Json.Encode.null << Maybe.map encodeComment) x.elmPostPromoted )
+        , ( "jsonPostAuthor", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string) x.elmPostAuthor )
         ]


### PR DESCRIPTION
First off, thanks so much for your work on this repo! And same to @jwoudenberg!

What do you think of this as a solution to krisajenkins#48?

TL;DR &ndash; I updated `Options` to the following, and applied these modifiers as needed in the type and de/encoder generation:

```haskell
data Options = Options                        
  { elmRecordFieldModifier :: Text -> Text
  , jsonKeyModifier :: Text -> Text                        
  }                                                        
```